### PR TITLE
Fail after all the errors are completed

### DIFF
--- a/patterns/gulpfile.js
+++ b/patterns/gulpfile.js
@@ -155,7 +155,7 @@ function jsLint() {
   return gulp.src( jsFiles )
     .pipe( eslint() )
     .pipe( eslint.format() )
-    .pipe( eslint.failOnError() );
+    .pipe( eslint.failAfterError() );
 }
 
 const webpackConfig = require('./webpack.config.js');


### PR DESCRIPTION
Instead of stop immediately we should wait before all errors are completed.