### PR TITLE
Added option to icons build to avoid collision with the icon ids

### DIFF
--- a/patterns/gulpfile.js
+++ b/patterns/gulpfile.js
@@ -15,6 +15,7 @@ const sassLint = require('gulp-sass-lint');
 const runSequence = require('run-sequence');
 const eslint = require( 'gulp-eslint');
 const svgstore = require( 'gulp-svgstore' );
+const svgmin = require('gulp-svgmin');
 const path = require('path');
 
 gulp.task( 'build', [ 'styles:build', 'js:build' ] );
@@ -231,6 +232,17 @@ const log = {
 function icons() {
   return gulp
     .src( [ 'static/icons/*.svg', '!static/icons/icons.svg' ] )
+    .pipe( svgmin(function( file ) {
+      const prefix = path.basename( file.relative, path.extname( file.relative ) );
+      return {
+        plugins: [{
+            cleanupIDs: {
+              prefix: prefix + '-',
+              minify: true
+            }
+        }]
+      }
+    }))
     .pipe( svgstore() )
     .pipe( gulp.dest( 'static/icons' ) );
 }

--- a/patterns/package.json
+++ b/patterns/package.json
@@ -14,6 +14,7 @@
     "gulp-sass": "^2.3.2",
     "gulp-sass-lint": "^1.3.2",
     "gulp-sourcemaps": "^1.9.1",
+    "gulp-svgmin": "^1.2.4",
     "gulp-svgstore": "^6.1.0",
     "gulp-util": "^3.0.7",
     "run-sequence": "^1.2.2",


### PR DESCRIPTION
I had an issue in Madison where the facebook icon was not showing correctly. After adding this option it was corrected.