### PR TITLE
Fix the Gutenberg edit icons and remove default border from images

### DIFF
--- a/frontend/components/atoms/base/reset.css
+++ b/frontend/components/atoms/base/reset.css
@@ -3,7 +3,11 @@ html {
    scroll-behavior: smooth;
 }
 
-svg {
-   @apply max-w-full max-h-full;
+*,
+*::before,
+*::after,
+img {
+  border-width: 1px;
+  border-style: none;
 }
 /* purgecss end ignore */


### PR DESCRIPTION
This SVG style is breaking the Guten blocks edit buttons. I think the SVG size should be limited by the parent element instead. Also there are some cases where we need to use the same SVG in different sizes, even bigger than the 100%.

Also the Tailwind utilities styles were affecting the images in the editor by adding a black border to them. I think images shouldn’t have a border style by default.